### PR TITLE
🐛 [frontend] justify gallery rows by rescaling instead of cropping

### DIFF
--- a/frontend/src/components/FileListView/react-grid-gallery/buildLayout.ts
+++ b/frontend/src/components/FileListView/react-grid-gallery/buildLayout.ts
@@ -5,31 +5,6 @@ import type {
   ImageExtendedRow,
 } from './types';
 
-const calculateCutOff = <T extends ImageExtended = ImageExtended>(
-  items: T[],
-  totalRowWidth: number,
-  protrudingWidth: number,
-) => {
-  const cutOff: number[] = [];
-  let cutSum = 0;
-  for (const i in items) {
-    const item = items[i];
-    const fractionOfWidth = item.scaledWidth / totalRowWidth;
-    cutOff[i] = Math.floor(fractionOfWidth * protrudingWidth);
-    cutSum += cutOff[i];
-  }
-
-  let stillToCutOff = protrudingWidth - cutSum;
-  while (stillToCutOff > 0) {
-    for (const i in cutOff) {
-      cutOff[i]++;
-      stillToCutOff--;
-      if (stillToCutOff < 0) break;
-    }
-  }
-  return cutOff;
-};
-
 const getRow = <T extends Image = Image>(
   images: T[],
   { containerWidth, rowHeight, margin }: BuildLayoutOptions,
@@ -58,14 +33,35 @@ const getRow = <T extends Image = Image>(
     totalRowWidth += extendedItem.scaledWidth + imgMargin;
   }
 
+  // Justify by rescaling the whole row to fit the container (standard
+  // justified-gallery behaviour) instead of horizontally cropping each image.
+  // Cropping cut into compositions: subjects on a rule-of-thirds line lost a
+  // flank of the frame, which read as badly framed thumbnails to clients.
   const protrudingWidth = totalRowWidth - containerWidth;
   if (row.length > 0 && protrudingWidth > 0) {
-    const cutoff = calculateCutOff(row, totalRowWidth, protrudingWidth);
-    for (const i in row) {
-      const pixelsToRemove = cutoff[i];
-      const item = row[i];
-      item.marginLeft = -Math.abs(Math.floor(pixelsToRemove / 2));
-      item.viewportWidth = item.scaledWidth - pixelsToRemove;
+    const marginsWidth = row.length * imgMargin;
+    const availableWidth = containerWidth - marginsWidth;
+    const naturalWidth = totalRowWidth - marginsWidth;
+    const scale = availableWidth / naturalWidth;
+    const scaledRowHeight = Math.floor(effectiveRowHeight * scale);
+    let usedWidth = 0;
+    for (const item of row) {
+      item.scaledHeight = scaledRowHeight;
+      item.scaledWidth = Math.floor(item.scaledWidth * scale);
+      usedWidth += item.scaledWidth;
+    }
+    // Hand the flooring remainder back one pixel at a time so the row fills
+    // the container edge-to-edge without ever overflowing it (overflow would
+    // break the flex-wrap row alignment).
+    let leftover = availableWidth - usedWidth;
+    for (const item of row) {
+      if (leftover <= 0) break;
+      item.scaledWidth += 1;
+      leftover -= 1;
+    }
+    for (const item of row) {
+      item.viewportWidth = item.scaledWidth;
+      item.marginLeft = 0;
     }
   }
 


### PR DESCRIPTION
**Summary**

The vendored `react-grid-gallery` justifies overflowing rows by horizontally
cropping every tile (narrowed viewport + negative `marginLeft`), which clips
compositions — subjects on rule-of-thirds lines lose a flank of the frame
(see #A). This PR switches `buildLayout.ts` to the standard justified-gallery
approach: **rescale the row to fit the container**. No image ever loses
pixels; row heights vary slightly per row instead. This also brings the grid
in line with the backend's own philosophy — thumbs are generated
`fit: 'inside'` specifically so clients see whole images.

**What changed**

- `getRow()`: when a row protrudes, compute
  `scale = availableWidth / naturalWidth` (margins excluded), apply to every
  tile's `scaledWidth`/`scaledHeight`, set `viewportWidth = scaledWidth`,
  `marginLeft = 0`.
- Widths floored, flooring remainder handed back 1 px at a time across the
  row → rows fill the container **exactly and never overflow** (a 1 px
  overflow would re-wrap the flat flex container).
- `calculateCutOff()` removed (unused).
- Row grouping unchanged — only how a row is fitted. Last row unchanged.

One file, 27 insertions, 31 deletions.

**Testing**

- Production build passes; no type/lint changes.
- Node harness on `buildLayout.ts` (20 mixed-aspect images): every non-last
  row fills the container exactly; zero cropped pixels; aspect preserved
  within rounding (≤2%, same class as the previous ±1 px cutoff); last row
  untouched.
- Rendered-DOM verification (stock vs patched side by side,
  `getBoundingClientRect`) at 1233/980/853 px: identical row structures, zero
  crop, zero overflow. Stock hid up to 67/215/105 px per tile.
- Running in production on my own instance.

<img width="2894" height="1656" alt="image" src="https://github.com/user-attachments/assets/2d463fc6-01f4-4c15-81c1-56ecec9605b7" />


**Behaviour note:** rows vary slightly in height (e.g. 165–180 px at
rowHeight 210) — the normal justified-layout signature. Rows only shrink;
tiles are never upscaled past rowHeight.