### PR TITLE
Fix RAW orientation handling

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -622,6 +622,15 @@ are deleted, regenerated, or the source media hash changes.
 - Existing decoded cache hits are trusted by existence, like generated
   thumbnails. New decoded intermediates must be validated before the atomic
   rename into the cache.
+- RAW embedded previews may omit the source file's Orientation tag. Copy only
+  that tag from the RAW file into the temporary JPEG, validate the preview, then
+  promote it without modifying the original RAW. Preview extraction tries
+  `JpgFromRaw`, `PreviewImage`, and `ThumbnailImage` in that order. The decoded
+  cache may retain EXIF orientation; thumbnail and blurhash generation must call
+  Sharp's `autoOrient()` before resizing or sampling.
+- Image ratios must use Sharp's orientation-aware metadata dimensions. This
+  keeps gallery layout and placeholders upright when decoded cache entries carry
+  orientation metadata instead of upright pixels.
 - `addFile()` uses a `typeChanged` gate so existing files reclassify during the
   normal boot scan when optional decoder capabilities appear. Do not bulk-clear
   `fileHash` to force this.

--- a/backend/media/blurHash.ts
+++ b/backend/media/blurHash.ts
@@ -5,6 +5,7 @@ import { openSharp } from './openSharp.js';
 export async function encodeImageToBlurhash(path: string): Promise<string> {
   try {
     const { data, info } = await openSharp(path)
+      .autoOrient()
       .raw()
       .ensureAlpha()
       .resize(32, 32, { fit: 'inside' })

--- a/backend/media/encodeThumbnail.ts
+++ b/backend/media/encodeThumbnail.ts
@@ -33,7 +33,10 @@ export const encodeThumbnail = async (
   const px = serverThumbnailDimensions(settings)[size];
   const jpgPath = outputPath('.jpg');
 
-  const img = openSharp(input).withMetadata().resize(px, px, sharpOpts);
+  const img = openSharp(input)
+    .autoOrient()
+    .withMetadata()
+    .resize(px, px, sharpOpts);
 
   const promises: Promise<OutputInfo>[] = [
     atomicWrite(jpgPath, (tempPath) =>

--- a/backend/media/ensureDecodedImage.ts
+++ b/backend/media/ensureDecodedImage.ts
@@ -84,6 +84,14 @@ const decodeRawPreview = async (
         ['-b', `-${tag}`, source],
         candidate,
       );
+      await runProcess(picrConfig.exiftoolPath ?? 'exiftool', [
+        '-m',
+        '-overwrite_original',
+        '-TagsFromFile',
+        source,
+        '-Orientation',
+        candidate,
+      ]);
       await validateCandidate(candidate);
       await rename(candidate, target);
       return;

--- a/backend/media/getImageRatio.ts
+++ b/backend/media/getImageRatio.ts
@@ -4,9 +4,10 @@ import { openSharp } from './openSharp.js';
 export const getImageRatio = async (filePath: string) => {
   try {
     const image = openSharp(filePath);
-    const { width, height } = await image.metadata();
-    if (!height || !width) return 0;
-    return height > 0 ? width / height : 0;
+    const { autoOrient } = await image.metadata();
+    const { width: displayedWidth, height: displayedHeight } = autoOrient;
+    if (!displayedHeight || !displayedWidth) return 0;
+    return displayedHeight > 0 ? displayedWidth / displayedHeight : 0;
   } catch (error) {
     logger.error('getImageRatio failed for ' + filePath);
     logger.error(String(error));


### PR DESCRIPTION
I find pretty annoying bug - when I upload RAW images - it displays in wrong orientation. For JPEGs all works good. 

I try to fix it as surgically as possible, for decrease possible impact.

Also attached how image look on PICR and actual image

<details>

<summary>Gallery view</summary>

<img width="1728" height="1117" alt="Screenshot 2026-08-29 at 19 31 11" src="https://github.com/user-attachments/assets/f33477cd-8299-4dce-9efb-59edd4b23c98" />

</details>


<details>

<summary>Actual preview</summary>

<img width="880" height="945" alt="Screenshot 2026-08-29 at 19 32 11" src="https://github.com/user-attachments/assets/6460db36-c56c-4d64-956e-5e9bd3c0c395" />

</details>